### PR TITLE
Add Select All Option

### DIFF
--- a/src/get-gitignore.js
+++ b/src/get-gitignore.js
@@ -66,7 +66,7 @@ function getGitIgnore(contents, selectAll = false) {
     const selectionsArray = selectionResponse.replace(' ', ',').split(',').filter(el => el.length > 0);
 
    // if the number for the select all option is listed, return everything
-    if (selectionsArray.indexOf(selectAllNumber) !== -1) {
+    if (selectionsArray.indexOf(selectAllNumber.toString()) !== -1) {
       return filtered; // returns an array of all the options
     };
 

--- a/src/get-gitignore.js
+++ b/src/get-gitignore.js
@@ -53,7 +53,7 @@ function getGitIgnore(contents, selectAll = false) {
       return filtered;
     }
 
-    console.log('Multiple possible options found! Please select one from the list.');
+    console.log('Multiple possible options found! Please select one or more options from the list.');
 
     filtered.forEach(function(element, index) {
       console.log((index + 1) + '. ' + element);
@@ -62,13 +62,17 @@ function getGitIgnore(contents, selectAll = false) {
     const selectAllNumber = filtered.length + 1;
     console.log(`${selectAllNumber}. Select All`);
 
-    const choice = readline.question('Enter a number from the above: ');
+    const selectionResponse = readline.question('Enter a number or separate multiple options with a comma (e.g. 1, 2, 3): ');
+    const selectionsArray = selectionResponse.replace(' ', ',').split(',').filter(el => el.length > 0);
 
-    if (choice == selectAllNumber) {
+   // if the number for the select all option is listed, return everything
+    if (selectionsArray.indexOf(selectAllNumber) !== -1) {
       return filtered; // returns an array of all the options
     };
 
-    relevantGitignores.push(filtered[choice - 1]);
+    selectionsArray.forEach(selectionNumber => {
+      relevantGitignores.push(filtered[selectionNumber - 1]);
+    })
     return relevantGitignores;
   }
 

--- a/src/get-gitignore.js
+++ b/src/get-gitignore.js
@@ -26,8 +26,10 @@ function applies(gitignore, contents) {
   return count; 
 }
 
-function getGitIgnore(contents, callback) {
+function getGitIgnore(contents, selectAll = false) {
   const ignored = {};
+  const relevantGitignores = []; // used to return an array of gitignores push into the local .gitignore
+
   gitignores.map(function(gitignore) {
     ignored[gitignore] = applies(gitignore, contents);
   });
@@ -42,20 +44,36 @@ function getGitIgnore(contents, callback) {
   }, 0);
 
   if (counts > 1) {
-    console.log('Multiple possible options found! Please select one from the list.');
     const filtered = Object.keys(pickBy(ignored, function(value, key) {
       return value === ignored[sorted[0]];
     }));
 
+    // if selectAll is true we'll skip the option display and just return all the options
+    if (selectAll) {
+      return filtered;
+    }
+
+    console.log('Multiple possible options found! Please select one from the list.');
+
     filtered.forEach(function(element, index) {
       console.log((index + 1) + '. ' + element);
     });
-    
+
+    const selectAllNumber = filtered.length + 1;
+    console.log(`${selectAllNumber}. Select All`);
+
     const choice = readline.question('Enter a number from the above: ');
-    return filtered[choice - 1];  
+
+    if (choice == selectAllNumber) {
+      return filtered; // returns an array of all the options
+    };
+
+    relevantGitignores.push(filtered[choice - 1]);
+    return relevantGitignores;
   }
 
-  return sorted[0];
+  relevantGitignores.push(sorted[0]);
+  return relevantGitignores;
 }
 
 module.exports = getGitIgnore;

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,10 @@ const contents = fs.readdirSync(cwd).map(function(element) {
   }
 });
 
-const gitignore = path.join(__dirname, '/../gitignores', getGitIgnore(contents));
+const gitignoresArray = getGitIgnore(contents);
 const filePath = path.join(cwd, '/.gitignore');
 
-fs.createReadStream(gitignore).pipe(fs.createWriteStream(filePath, { flags: 'a' }));
+gitignoresArray.forEach((element, index) => {
+  const gitignore = path.join(__dirname, '/../gitignores', element);
+  fs.createReadStream(gitignore).pipe(fs.createWriteStream(filePath, { flags: 'a' }));
+})

--- a/tests/index.js
+++ b/tests/index.js
@@ -4,17 +4,20 @@ const chai = require('chai');
 const expect = chai.expect;
 const getGitIgnore = require('../src/get-gitignore');
 
+// sample project contents fixtures
+const npmContents = ['src/', 'node_modules/', 'package.json', '.env', '.npm'];
+const pythonContents = ['src/', 'main.pyc', 'wheels/'];
+const combinedContents = npmContents.concat(pythonContents);
+
 describe('getGitIgnore', function() {
   it('gets the right .gitignore for a probable Node project', function() {
-    const contents = ['src/', 'node_modules/', 'package.json', '.env', '.npm'];
-    expect(getGitIgnore(contents)).to.contain('Node.gitignore');
+    expect(getGitIgnore(npmContents)).to.contain('Node.gitignore');
   });
   it('gets the right .gitignore for a probable Python project', function() {
     const contents = ['src/', 'main.pyc', 'wheels/'];
-    expect(getGitIgnore(contents)).to.contain('Python.gitignore');
+    expect(getGitIgnore(pythonContents)).to.contain('Python.gitignore');
   });
   it('gets a .gitignore for project with Node and Python', function() {
-    const contents = ['src/', 'node_modules/', 'package.json', '.env', '.npm', 'src/', 'main.pyc', 'wheels/'];
-    expect(getGitIgnore(contents, true)).to.eql(['Node.gitignore', 'Python.gitignore']);
+    expect(getGitIgnore(combinedContents, true)).to.eql(['Node.gitignore', 'Python.gitignore']);
   });
 });

--- a/tests/index.js
+++ b/tests/index.js
@@ -7,10 +7,14 @@ const getGitIgnore = require('../src/get-gitignore');
 describe('getGitIgnore', function() {
   it('gets the right .gitignore for a probable Node project', function() {
     const contents = ['src/', 'node_modules/', 'package.json', '.env', '.npm'];
-    expect(getGitIgnore(contents)).to.equal('Node.gitignore');
+    expect(getGitIgnore(contents)).to.contain('Node.gitignore');
   });
   it('gets the right .gitignore for a probable Python project', function() {
     const contents = ['src/', 'main.pyc', 'wheels/'];
-    expect(getGitIgnore(contents)).to.equal('Python.gitignore');
+    expect(getGitIgnore(contents)).to.contain('Python.gitignore');
+  });
+  it('gets a .gitignore for project with Node and Python', function() {
+    const contents = ['src/', 'node_modules/', 'package.json', '.env', '.npm', 'src/', 'main.pyc', 'wheels/'];
+    expect(getGitIgnore(contents, true)).to.eql(['Node.gitignore', 'Python.gitignore']);
   });
 });


### PR DESCRIPTION
Fixes #1.

This adds the `Select All` option when there are more than one gitignore that is relevant. Selecting that number will push all of the options into the `.gitignore` file.

A couple of comments:

* I took out the `callback` from `getGitIgnore` b/c I didn't see it being used at all (wasn't even being called).
* I added a `selectAll` arg to `getGitIgnore` for testing mainly, but you might want to add a flag in the future. (i.e. `goops --all` to just skip right to using everything that matches.)

If you have any comments or adjustments please LMK! 